### PR TITLE
Update `CONTRIBUTING.md` to a newer approach from GitHub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ Also, for testing locally use:
 # it from failing while trying to lint an inexisting file, while allowing it to self-test
 # Replace <user> with your GitHub user name
 # Replace <branch> with the branch you pushed
-asdf plugin test markdownlint-cli2 https://github.com/<user>/asdf-markdownlint-cli2.git "markdownlint-cli2 _version" --asdf-plugin-gitref <branch>
+asdf plugin test markdownlint-cli2 git@github.com:<user>/asdf-markdownlint-cli2.git "markdownlint-cli2 _version" --asdf-plugin-gitref <branch>
 ```
 <!-- markdownlint-enable -->
 


### PR DESCRIPTION
# Description

Use `git@github.com:` instead of `https://`.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/paulo-ferraz-oliveira/asdf-markdownlint-cli2/blob/main/CONTRIBUTING.md)
