### PR TITLE
Replace `which` calls with `command -v`

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -44,11 +44,11 @@ ensure() {
 }
 
 ensure_node() {
-	ensure "which node" "it appears node is not available"
+	ensure "command -v node" "it appears node is not available"
 }
 
 ensure_npm() {
-	ensure "which npm" "it appears npm is not available"
+	ensure "command -v npm" "it appears npm is not available"
 }
 
 download_release() {


### PR DESCRIPTION
`command -v` is built in, and `which` needs to be installed.

# Description

A brief description of your changes.

Closes #&lt;issue&gt;.

- [ ] I have performed a self-review of my changes
- [ ] I have read and understood the [contributing guidelines](/paulo-ferraz-oliveira/asdf-markdownlint-cli2/blob/main/CONTRIBUTING.md)
