### PR TITLE
Prevent circular dependency

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,5 +4,4 @@ A brief description of your changes.
 
 Closes #&lt;issue&gt;.
 
-- [ ] I have performed a self-review of my changes
 - [ ] I have read and understood the [contributing guidelines](/paulo-ferraz-oliveira/asdf-markdownlint-cli2/blob/main/CONTRIBUTING.md)

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -77,7 +77,11 @@ install_version() {
 		cp -r "$ASDF_DOWNLOAD_PATH"/* "$install_path"
 		ensure_node
 		ensure_npm
+		# Move the package's own package.json aside to prevent a circular
+		# self-dependency that causes npm to hang indefinitely.
+		mv "$install_path/package.json" "$install_path/package.json.upstream"
 		npm --silent install --prefix "$install_path" markdownlint-cli2 --save-dev >/dev/null
+		mv "$install_path/package.json.upstream" "$install_path/package.json"
 
 		local tool_cmd
 		tool_cmd="bin/$(echo "$TOOL_TEST" | cut -d' ' -f1)"


### PR DESCRIPTION
# Description

Prevents a circular dependency hang, per linked issue.

Closes #62.

- [x] I have read and understood the [contributing guidelines](/paulo-ferraz-oliveira/asdf-markdownlint-cli2/blob/main/CONTRIBUTING.md)
